### PR TITLE
Update for OpenID Connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This gem contains the Line OAuth2 Strategy for OmniAuth.
 
-Supports the OAuth 2.0 Web Login. Read the Line developers docs for more details: https://developers.line.me/web-login/integrating-web-login
+Supports the OpenID Connect Web Login. Read the Line developers docs for more details: https://developers.line.me/en/docs/line-login/web/integrate-line-login/
 
 ## Using This Strategy
 

--- a/lib/omniauth/strategies/line.rb
+++ b/lib/omniauth/strategies/line.rb
@@ -5,11 +5,12 @@ module OmniAuth
   module Strategies
     class Line < OmniAuth::Strategies::OAuth2
       option :name, 'line'
+      option :scope, 'profile openid'
 
       option :client_options, {
         site: 'https://access.line.me',
-        authorize_url: '/dialog/oauth/weblogin',
-        token_url: '/v2/oauth/accessToken'
+        authorize_url: '/oauth2/v2.1/authorize',
+        token_url: '/oauth2/v2.1/token'
       }
 
       # host changed

--- a/spec/omniauth/strategies/line_spec.rb
+++ b/spec/omniauth/strategies/line_spec.rb
@@ -22,11 +22,11 @@ describe OmniAuth::Strategies::Line do
     end
 
     it 'should have correct authorize url' do
-      expect(subject.options.client_options.authorize_url).to eq('/dialog/oauth/weblogin')
+      expect(subject.options.client_options.authorize_url).to eq('/oauth2/v2.1/authorize')
     end
 
     it 'should have correct token url' do
-      expect(subject.options.client_options.token_url).to eq('/v2/oauth/accessToken')
+      expect(subject.options.client_options.token_url).to eq('/oauth2/v2.1/token')
     end
   end
 


### PR DESCRIPTION
We can use OpenID Connect protocol to login with LINE. 
https://developers.line.me/en/docs/line-login/web/integrate-line-login/

This pull request is for the new LINE login protocol.
* The authorization and token request endpoint are changed
* set the default scope(profile and openid)