### PR TITLE
Fix AccessToken API error

### DIFF
--- a/lib/omniauth/strategies/line.rb
+++ b/lib/omniauth/strategies/line.rb
@@ -13,6 +13,8 @@ module OmniAuth
         token_url: '/oauth2/v2.1/token'
       }
 
+      option :token_option[:client_id, :client_secret]
+
       # host changed
       def callback_phase
         options[:client_options][:site] = 'https://api.line.me'


### PR DESCRIPTION
Line Access Token API requires `client_id ` and `client_secret `.

https://developers.line.me/ja/docs/line-login/web/integrate-line-login/