### PR TITLE
Remove upper version for omniauth-oauth2

### DIFF
--- a/omniauth-line.gemspec
+++ b/omniauth-line.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'json', '~> 1.3'
-  s.add_dependency 'omniauth-oauth2', '~>1.3.1'
-  s.add_development_dependency 'bundler', '~> 1.0'
+  s.add_dependency 'omniauth-oauth2'
+  s.add_development_dependency 'bundler'
 
 end


### PR DESCRIPTION
Other omniauth strategy gems such as [omniauth-google-oauth2](https://rubygems.org/gems/omniauth-google-oauth2) depends omniauth-oauth v1.6 or later version. If we use both gems in an application, these gems conflict with omniauth-oauth version.

omniauth-line seems to work with omniauth-oauth v1.6 (I tested at local machine and it passes all specs), so I think that omniauth-line does not have to set upper version for omniauth-oauth.