### PR TITLE
Add gitignore file with auto generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/Gemfile.lock
+/coverage/


### PR DESCRIPTION
Running bundle install and rspec on this repository generates Gemfile.lock and coverage files which are not needed to commit.