### PR TITLE
Upgrade omniauth-oauth2 version to 1.6 and fix callback_url issue.

### DIFF
--- a/lib/omniauth/strategies/line.rb
+++ b/lib/omniauth/strategies/line.rb
@@ -36,6 +36,10 @@ module OmniAuth
         raise ::Timeout::Error
       end
 
+      def callback_url
+        # Fixes regression in omniauth-oauth2 v1.4.0 by https://github.com/intridea/omniauth-oauth2/commit/85fdbe117c2a4400d001a6368cc359d88f40abc7
+        options[:callback_url] || (full_host + script_name + callback_path)
+      end
     end
   end
 end

--- a/omniauth-line.gemspec
+++ b/omniauth-line.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'json', '~> 1.3'
-  s.add_dependency 'omniauth-oauth2', '~>1.3.1'
+  s.add_dependency 'omniauth-oauth2', '~>1.6.0'
   s.add_development_dependency 'bundler', '~> 1.0'
 
 end


### PR DESCRIPTION
This PR is similar to [that PR](https://github.com/kazasiki/omniauth-line/pull/10), but the version of omniauth-oauth2 has been upgraded to 1.6.

Since omniauth-google enforces 1.6 or higher, an upgrade is required to use it at the same time.

https://github.com/zquestz/omniauth-google-oauth2/blob/e2ace464ac2025bb287e78f7ac0a1249c73658b1/omniauth-google-oauth2.gemspec#L25