### PR TITLE
Update dependencies for modern ruby

### DIFF
--- a/omniauth-line.gemspec
+++ b/omniauth-line.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'json', '~> 1.3'
+  s.add_dependency 'json', '~> 2.3'
   s.add_dependency 'omniauth-oauth2', '~>1.3.1'
-  s.add_development_dependency 'bundler', '~> 1.0'
+  s.add_development_dependency 'bundler', '~> 2.0'
 
 end


### PR DESCRIPTION
json gem complains at version ~> 1.3 in ruby 2.7+
`json-1.8.6/lib/json/common.rb:155: warning: Using the last argument as keyword parameters is deprecated`
json has since been updated but the current gemspec was restricted to 1.8.6 which has not been fixed and is no longer maintained.

Also updated to bundler v2 as development dependency