### PR TITLE
update dependencies

### DIFF
--- a/omniauth-line.gemspec
+++ b/omniauth-line.gemspec
@@ -17,8 +17,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'json', '~> 1.3'
-  s.add_dependency 'omniauth-oauth2', '~>1.3.1'
-  s.add_development_dependency 'bundler', '~> 1.0'
-
+  s.add_dependency 'json', '>= 2.3.0'
+  s.add_dependency 'omniauth-oauth2', '~>1.3'
+  s.add_development_dependency 'bundler', '~> 2.0'
 end


### PR DESCRIPTION
- update dependencies
  - update json >= 2.3.0
    - some security reason
  - loosen omniauth-oauth2 dependency
  - update bundler ~> 2.0
    - because newer ruby is bundler >= 2 is default.

- close #5, #6, #13, #14, #20