### PR TITLE
fix Line Login error 

### DIFF
--- a/lib/omniauth/strategies/line.rb
+++ b/lib/omniauth/strategies/line.rb
@@ -19,6 +19,11 @@ module OmniAuth
         super
       end
 
+      def callback_url
+        # Fixes regression in omniauth-oauth2 v1.4.0 by https://github.com/intridea/omniauth-oauth2/commit/85fdbe117c2a4400d001a6368cc359d88f40abc7
+        options[:callback_url] || (full_host + script_name + callback_path)
+      end
+      
       uid { raw_info['userId'] }
 
       info do


### PR DESCRIPTION
with omniauth-oauth2 v1.4.0 or higher, we are not able to login to Line because of lacking of callback_url.

https://github.com/omniauth/omniauth-oauth2/pull/70
with this change, callback_url method was deleted.

while we use omniauth-line with omniauth-oauth2 v1.4.0 or higher, we always have this error.
```
ERROR -- omniauth: (line) Authentication failure! invalid_credentials: OAuth2::Error, invalid_grant: redirect_uri does not match
```
to fix this error, I added callback_url method.
