### PR TITLE
Release 0.1.1 - add dependency constraint for omniauth 1.x

### DIFF
--- a/lib/omniauth-line/version.rb
+++ b/lib/omniauth-line/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Line
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end

--- a/omniauth-line.gemspec
+++ b/omniauth-line.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'json', '>= 2.3.0'
+  s.add_dependency 'omniauth', '~> 1.2'
   s.add_dependency 'omniauth-oauth2', '~>1.3'
   s.add_development_dependency 'bundler', '~> 2.0'
 end

--- a/spec/omniauth/strategies/line_spec.rb
+++ b/spec/omniauth/strategies/line_spec.rb
@@ -73,6 +73,15 @@ describe OmniAuth::Strategies::Line do
     end
   end
 
+  describe '#callback_url' do
+    it 'should returns callback url' do
+      base_url = 'https://example.com'
+      allow(subject).to receive(:full_host) { base_url }
+      allow(subject).to receive(:script_name) { '/v1' }
+      expect(subject.send(:callback_url)).to eq "#{base_url}/v1/auth/line/callback"
+    end
+  end
+
 end
 
 private


### PR DESCRIPTION
Hi, @kazasiki

Could you review this PR about #32 issue?

I tested manually in remote server with https communication environment, and confirmed following.

- should use omniauth 1.x series.
- should return credentials in auth hash. (regression scenarios)

If you want to try my branch, you can use like following in your Gemfile.

```rb
gem 'omniauth-line', github: 'koshilife/omniauth-line', branch: '#32_add_dependency_constraint_for_omniauth_1.x'
```
